### PR TITLE
Fix tab order of comment form elements in river view.

### DIFF
--- a/layout/_menu.xhtml
+++ b/layout/_menu.xhtml
@@ -39,7 +39,7 @@
 
     <div id="main-menu-container" class="#{account.custom_link ? 'with-custom' : ''}">
       <form action="/search" method="POST" class="search">
-        <input id="search" type="text" name="q" tabindex="99"/>
+        <input id="search" type="text" name="q"/>
       </form>
       <?r if session[:layout] != 'narrow' ?>
       <a href="http://issues.libertreeproject.org" class="menu-item" title="#{s_('menu|Known Issues')}">#{img 'icon-exclamation.png', {alt:s_('menu|Known Issues')}}</a>

--- a/scss/application.scss
+++ b/scss/application.scss
@@ -556,6 +556,7 @@ blockquote {
         height: 24px;
         padding-left: 4px;
         padding-right: 4px;
+        float: right;
     }
 }
 

--- a/view/comments/_comments_list.xhtml
+++ b/view/comments/_comments_list.xhtml
@@ -25,13 +25,13 @@
         </div>
         <form method="POST" action="/comments/create" class="comment" data-post-id="#{@post.id}">
           #{ Controller::Main.render_partial '_markdown_injector' }
-          <textarea name="text" class="comment textarea-comment-new" rows="2" tabindex="1" id="textarea-comment-on-post-#{@post.id}">#{session[:saved_text]["textarea-comment-on-post-#{@post.id}"]}</textarea>
+          <textarea name="text" class="comment textarea-comment-new" rows="2" id="textarea-comment-on-post-#{@post.id}">#{session[:saved_text]["textarea-comment-on-post-#{@post.id}"]}</textarea>
           <div class="form-buttons">
             <a class="detach" href="#">#{_('detach')}</a>
             <a class="attach" href="#">#{_('attach')}</a>
-            <input class="textarea-clear" data-textarea-id="textarea-comment-on-post-#{@post.id}" type="button" value="#{_('Clear')}" tabindex="4"/>
-            <input class="preview" type="button" value="#{_('Preview')}" tabindex="3" data-type="comment" data-preview-heading="#{_('Preview')}" data-preview-close-label="#{s_('preview|close')}" />
-            <input class="submit" data-msg-failure="#{_('Failed to post comment.')}" type="button" value="#{@post.v_internet? ? _('Comment to Internet') : _('Comment')}" tabindex="2"/>
+            <input class="submit" data-msg-failure="#{_('Failed to post comment.')}" type="button" value="#{@post.v_internet? ? _('Comment to Internet') : _('Comment')}"/>
+            <input class="preview" type="button" value="#{_('Preview')}" data-type="comment" data-preview-heading="#{_('Preview')}" data-preview-close-label="#{s_('preview|close')}"/>
+            <input class="textarea-clear" data-textarea-id="textarea-comment-on-post-#{@post.id}" type="button" value="#{_('Clear')}"/>
           </div>
         </form>
       <?r end ?>


### PR DESCRIPTION
The original bug was that, when having more than one comment form on the page,
pressing Tab from one comment input box would not go to the Comment button
related to that input field, but rather would jump to the next comment form's
input box.
