### PR TITLE
When creating request:MESSAGE job, new parameter expected

### DIFF
--- a/controller/messages.rb
+++ b/controller/messages.rb
@@ -39,9 +39,9 @@ module Controller
             {
               task: 'request:MESSAGE',
               params: {
-                'message_id'          => message.id,
-                'server_id'           => tree.id,
-                'recipient_usernames' => recipients.map(&:username)
+                'message_id'           => message.id,
+                'server_id'            => tree.id,
+                'recipient_member_ids' => recipients.map(&:id)
               }.to_json,
             }
           )


### PR DESCRIPTION
 is recipient_member_ids.

See also:

https://github.com/Libertree/libertree/pull/8
https://github.com/Libertree/libertree-model-rb/pull/5
https://github.com/Libertree/libertree-client-rb/pull/2
https://github.com/Libertree/libertree-backend-rb/pull/5
