### PR TITLE
concatenate all scripts in the Libertree namespace

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -7,6 +7,23 @@ require 'fast_gettext'
 require 'markdown'
 require_relative 'lib/libertree/lang'
 
+# concatenate all files in public/js/libertree/
+libertree_js = [ "session",
+                 "post_loader",
+                 "ui",
+                 "intro",
+                 "pools",
+                 "notifications",
+                 "chat",
+                 "likes",
+                 "posts",
+                 "comments" ].reduce("var Libertree = {};") do |res, filename|
+  res += IO.read("public/js/libertree/#{filename}.js")
+end
+File.open("public/js/libertree.js", "w") do |file|
+  file.write libertree_js
+end
+
 [ 'frontend', 'email' ].each do |domain|
   FastGettext.add_text_domain(domain, :path => 'locale', :type => :po)
 end

--- a/layout/_head.xhtml
+++ b/layout/_head.xhtml
@@ -30,15 +30,6 @@
   #{ js 'bootstrap.tooltip.popover' }
 
   #{ js_nocache 'libertree' }
-  #{ js_nocache 'libertree/post_loader' }
-  #{ js_nocache 'libertree/ui' }
-  #{ js_nocache 'libertree/session' }
-  #{ js_nocache 'libertree/pools' }
-  #{ js_nocache 'libertree/notifications' }
-  #{ js_nocache 'libertree/chat' }
-  #{ js_nocache 'libertree/likes' }
-  #{ js_nocache 'libertree/posts' }
-  #{ js_nocache 'libertree/comments' }
   #{ js_nocache 'application' }
   #{ js_nocache 'comments' }
   #{ js_nocache 'markdown-injector' }

--- a/layout/splash.xhtml
+++ b/layout/splash.xhtml
@@ -18,9 +18,6 @@
 
   #{ js_nocache 'login' }
   #{ js_nocache 'libertree' }
-  #{ js_nocache 'libertree/ui' }
-  #{ js_nocache 'libertree/intro' }
-  #{ controller_js }
 </head>
 
 <body class="#{ @view }">

--- a/public/js/libertree.js
+++ b/public/js/libertree.js
@@ -1,1 +1,0 @@
-var Libertree = {};


### PR DESCRIPTION
- all files in public/js/libertree/ are concatenated in the correct order
- reduces the number of HTTP requests made per page hit
