### PR TITLE
Repair the feature that disabled textarea autoresize upon manual resize.

### DIFF
--- a/public/js/application.js
+++ b/public/js/application.js
@@ -95,19 +95,16 @@ $(document).ready( function() {
 
   /* ---------------------------------------------------- */
 
-  $(document).on('mousedown', 'textarea', function() {
-    var $this = $(this);
-    $this.data('width', $this.outerWidth());
-    $this.data('height', $this.outerHeight());
-  } );
-
-  $(document).on('mouseup', 'textarea', function() {
-    var th = $(this);
-    if( th.outerWidth() != th.data('width') || th.outerHeight() != th.data('height') ) {
-      th.addClass('no-autoresize');
-    }
-    th.data('width', th.outerWidth());
-    th.data('height', th.outerHeight());
+  /* Disable autoresize on any textarea that is manually resized */
+  $(document).on('mouseup', function() {
+    $('textarea').each( function() {
+      var th = $(this);
+      if( th.outerWidth() != th.data('original-width') || th.outerHeight() != th.data('original-height') ) {
+        th.addClass('no-autoresize');
+      }
+      th.data('original-width', th.outerWidth());
+      th.data('original-height', th.outerHeight());
+    } );
   } );
 
   $(document).on('click', '.markdown-injector a', Libertree.UI.markdownInjector);

--- a/public/js/jquery.expandable.js
+++ b/public/js/jquery.expandable.js
@@ -106,6 +106,9 @@
                         newHeight = Math.max( height - (rowSize * (availableRows - (options.by + options.within))), minHeight );
                         $this.stop().animate({ height: newHeight }, options.duration);
                     }
+                    $('textarea').data('original-width', $this.outerWidth());
+                    $('textarea').data('original-height', $this.outerHeight());
+
                 };
                 if ( options.init ) check();
             }).end();

--- a/public/js/libertree/ui.js
+++ b/public/js/libertree/ui.js
@@ -216,7 +216,11 @@ Libertree.UI = (function () {
     }()),
 
     makeTextAreasExpandable: function() {
-      $('textarea').not('.textarea-chat').expandable( { maxRows: 60 } );
+      $('textarea').not('.textarea-chat').each( function() {
+        $(this).expandable( { maxRows: 60 } );
+        $(this).data('original-width', $(this).outerWidth());
+        $(this).data('original-height', $(this).outerHeight());
+      } );
     },
 
     scrollable: function() {


### PR DESCRIPTION
For some reason, Chrome no longer fires a mousedown event on the manual resizer handle,
so our code stopped working.
